### PR TITLE
add pkg_upgrade

### DIFF
--- a/files/opnsense.fact
+++ b/files/opnsense.fact
@@ -18,12 +18,12 @@ if [ -x /usr/local/opnsense/scripts/firmware/changelog.sh ]; then
 	echo ","
 fi
 
-echo "\"ansible_opnsense_facts_version\": \"0.2\","
-
 if [ -e /tmp/pkg_upgrade.json ]; then
   echo "\"pkg_upgrade\": ["
   cat /tmp/pkg_upgrade.json
-  echo "]"
+  echo "],"
 fi
+
+echo "\"ansible_opnsense_facts_version\": \"0.2\""
 
 echo "}"

--- a/files/opnsense.fact
+++ b/files/opnsense.fact
@@ -1,5 +1,9 @@
 #! /bin/sh
 
+if [ -z "$(find /tmp/pkg_upgrade.json -cmin -5)" ]; then
+  /usr/local/opnsense/scripts/firmware/check.sh > /dev/null
+fi
+
 echo "{"
 
 cd /usr/local/opnsense/version/
@@ -14,7 +18,12 @@ if [ -x /usr/local/opnsense/scripts/firmware/changelog.sh ]; then
 	echo ","
 fi
 
+echo "\"ansible_opnsense_facts_version\": \"0.2\","
 
-echo "\"ansible_opnsense_facts_version\": \"0.1\""
+if [ -e /tmp/pkg_upgrade.json ]; then
+  echo "\"pkg_upgrade\": ["
+  cat /tmp/pkg_upgrade.json
+  echo "]"
+fi
 
 echo "}"


### PR DESCRIPTION
get data generated by /usr/local/opnsense/scripts/firmware/check.sh for Rosa-Luxemburgstiftung-Berlin/ansible-opnsense-update/issues/6

Bumbed versionnumber

The 5 minutes to not always trigger the script might be a bit too long for minor upgrades now that i think about it `¯\_(ツ)_/¯`.

Or maybe the upgrade-job from ansible-opnsense-update should just delete it for such cases?


