### PR TITLE
PR to add missing meta/main.yml

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,11 +2,13 @@
 dependencies: []
 
 galaxy_info:
-  author: rudi.broekhuizen
-  description: Ansible role for OPNSense deployment on appliances
-  company: Naturalis Biodiversity Center
-  license: Apache2
-  min_ansible_version: 2.13.0
+  author: zerwes, crpb
+  description: Ansible role for deploying ansible facts on OPNSense appliances
+  company: Rosa-Luxemburg-Stiftung Gesellschaftsanalyse und politische Bildung e. V.
+
+
+  license: GPL 3.0
+  min_ansible_version: 2.9.0
   platforms:
     - name: FreeBSD
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,17 @@
+---
+dependencies: []
+
+galaxy_info:
+  author: rudi.broekhuizen
+  description: Ansible role for OPNSense deployment on appliances
+  company: Naturalis Biodiversity Center
+  license: Apache2
+  min_ansible_version: 2.13.0
+  platforms:
+    - name: FreeBSD
+      versions:
+        - all
+  galaxy_tags:
+    - opnsense
+    - firewall
+    - freebsd


### PR DESCRIPTION
Using ansible-galaxy cli to install this role fails because the cli insists on there being a meta/main.yml.

```
$ ansible-galaxy role install -r requirements.yml
[WARNING]: - opnsense-facts was NOT installed successfully: this role does not appear to have a meta/main.yml file.
```

I just copied the meta file from your opnsense role so you may wish to change the content.
